### PR TITLE
Amended Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -73,7 +73,8 @@ libepetreco.a : \
 
 
 %.out : \
-        $(TESTS_SRC)/%.cu
+        $(TESTS_SRC)/%.cu \
+	libepetreco.a
 	CPLUS_INCLUDE_PATH= ; \
   $(CUC) $(CUCFLAGS) $(CUCINC) $(CUCLIB) $^ -o $@
 
@@ -82,7 +83,8 @@ libepetreco.a : \
 	$(CPPC) $(CPPCFLAGS) $(INC) $(LIB) $^ -o $@
 
 %.out : \
-        $(SRC)/%.cu
+        $(SRC)/%.cu \
+	libepetreco.a
 	CPLUS_INCLUDE_PATH= ; \
   $(CUC) $(CUCFLAGS) $(CUCINC) $(CUCLIB) $^ -o $@
 

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 SRC = ./src
-TESTS_SRC = ./src/tests
+TESTS_SRC = $(SRC)/tests
 PLY = $(SRC)/Ply
 
 CPPC = g++

--- a/Makefile
+++ b/Makefile
@@ -51,12 +51,8 @@ default : $(EXECUTABLES)
 
 clean:
 	rm \
-      $(EXECUTABLES) \
-      ./libepetreco.a \
-      ./*.ply \
-      ./*.h5 2>/dev/null; \
-  cd ./src/external_library_examples/ && make clean 2>/dev/null
-
+        $(EXECUTABLES) \
+        ./libepetreco.a
 
 libepetreco.a : \
         PlyGeometry.o \
@@ -123,24 +119,3 @@ PlyWriter.o : \
       $(PLY)/PlyWriter.cpp\
       $(PLY)/PlyWriter.hpp
 	$(CPPC) $(CPPCFLAGS) $(INC) -c $< -o $@
-
-
-
-# build tests
-build-tests: .build-tests-post
-
-.build-tests-pre:
-# Add your pre 'build-tests' code here...
-
-.build-tests-post: .build-tests-impl
-# Add your post 'build-tests' code here...
-
-
-# run tests
-test: .test-post
-
-.test-pre:
-# Add your pre 'test' code here...
-
-.test-post: .test-impl
-# Add your post 'test' code here...


### PR DESCRIPTION
Was: Had stale targets that lacked libepetreco.a as a dependency.
Is: Targets have libepetreco.a as a dependency.
